### PR TITLE
Blog目次とNotionブロック表示を改善

### DIFF
--- a/src/components/BlogTableOfContents.astro
+++ b/src/components/BlogTableOfContents.astro
@@ -1,0 +1,232 @@
+---
+export interface TableOfContentsItem {
+  id: string
+  text: string
+  level: 1 | 2 | 3
+}
+
+export interface Props {
+  items: TableOfContentsItem[]
+}
+
+const { items } = Astro.props
+---
+
+{
+  items.length > 0 && (
+    <nav class="blog-toc" aria-label="記事の目次">
+      <p class="blog-toc__title">目次</p>
+      <ol class="blog-toc__list">
+        {items.map((item) => (
+          <li class={`blog-toc__item blog-toc__item--level-${item.level}`}>
+            <a
+              class="blog-toc__link"
+              href={`#${item.id}`}
+              data-heading-id={item.id}
+            >
+              <span class="blog-toc__marker" aria-hidden="true" />
+              <span class="blog-toc__text">{item.text}</span>
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  )
+}
+
+<script is:inline data-astro-rerun>
+  (() => {
+    const links = Array.from(document.querySelectorAll('.blog-toc__link'))
+    if (!links.length) return
+
+    const sections = links
+      .map((link) => {
+        const id = link.getAttribute('data-heading-id')
+        if (!id) return null
+        const target = document.getElementById(id)
+        if (!target) return null
+        return { link, target }
+      })
+      .filter(Boolean)
+
+    if (!sections.length) return
+
+    const setActive = (activeLink) => {
+      links.forEach((link) => {
+        link.classList.toggle('is-active', link === activeLink)
+        if (link === activeLink) {
+          link.setAttribute('aria-current', 'location')
+        } else {
+          link.removeAttribute('aria-current')
+        }
+      })
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visibleEntries = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+
+        if (!visibleEntries.length) return
+
+        const active = sections.find(
+          (section) => section.target === visibleEntries[0].target
+        )
+
+        if (active) setActive(active.link)
+      },
+      {
+        rootMargin: '-18% 0px -72% 0px',
+        threshold: [0, 1],
+      }
+    )
+
+    sections.forEach((section) => observer.observe(section.target))
+    setActive(sections[0].link)
+  })()
+</script>
+
+<style>
+  .blog-toc {
+    position: relative;
+    width: 100%;
+    color: #6b6478;
+  }
+
+  .blog-toc__title {
+    margin: 0 0 0.7rem;
+    color: #3f394d;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+  }
+
+  .blog-toc__list {
+    position: relative;
+    display: grid;
+    gap: 0.15rem;
+    margin: 0;
+    padding: 0.2rem 0 0.2rem 0.1rem;
+    list-style: none;
+  }
+
+  .blog-toc__list::before {
+    content: '';
+    position: absolute;
+    top: 0.35rem;
+    bottom: 0.35rem;
+    left: 0.42rem;
+    width: 1px;
+    border-radius: 999px;
+    background: rgba(124, 108, 242, 0.18);
+  }
+
+  .blog-toc__item {
+    min-width: 0;
+  }
+
+  .blog-toc__item--level-2 {
+    padding-left: 0.85rem;
+  }
+
+  .blog-toc__item--level-3 {
+    padding-left: 1.55rem;
+  }
+
+  .blog-toc__link {
+    position: relative;
+    display: grid;
+    grid-template-columns: 0.85rem minmax(0, 1fr);
+    gap: 0.45rem;
+    align-items: start;
+    min-height: 1.55rem;
+    border-radius: 999px;
+    color: inherit;
+    text-decoration: none;
+    transition:
+      color 160ms ease,
+      background-color 160ms ease;
+  }
+
+  .blog-toc__link:hover,
+  .blog-toc__link:focus-visible,
+  .blog-toc__link.is-active {
+    color: #4f43c7;
+  }
+
+  .blog-toc__marker {
+    position: relative;
+    z-index: 1;
+    width: 0.45rem;
+    height: 0.45rem;
+    margin: 0.48rem auto 0;
+    border: 1px solid rgba(124, 108, 242, 0.35);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.92);
+    transition:
+      border-color 160ms ease,
+      background-color 160ms ease,
+      transform 160ms ease;
+  }
+
+  .blog-toc__link:hover .blog-toc__marker,
+  .blog-toc__link:focus-visible .blog-toc__marker,
+  .blog-toc__link.is-active .blog-toc__marker {
+    border-color: rgba(124, 108, 242, 0.9);
+    background: #7c6cf2;
+    transform: scale(1.18);
+  }
+
+  .blog-toc__text {
+    overflow: hidden;
+    padding: 0.18rem 0.35rem 0.18rem 0;
+    font-size: 0.84rem;
+    line-height: 1.45;
+    text-overflow: ellipsis;
+  }
+
+  @media (max-width: 1180px) {
+    .blog-toc {
+      width: 2.8rem;
+      padding: 0.6rem 0;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.72);
+      box-shadow: 0 16px 36px rgba(76, 60, 120, 0.08);
+      transition:
+        width 180ms ease,
+        padding 180ms ease,
+        border-radius 180ms ease;
+    }
+
+    .blog-toc:hover,
+    .blog-toc:focus-within {
+      width: min(17rem, calc(100vw - 2rem));
+      padding: 0.9rem 0.95rem;
+      border-radius: 18px;
+      background: rgba(255, 255, 255, 0.96);
+    }
+
+    .blog-toc__title,
+    .blog-toc__text {
+      opacity: 0;
+      transition: opacity 140ms ease;
+    }
+
+    .blog-toc:hover .blog-toc__title,
+    .blog-toc:focus-within .blog-toc__title,
+    .blog-toc:hover .blog-toc__text,
+    .blog-toc:focus-within .blog-toc__text {
+      opacity: 1;
+    }
+
+    .blog-toc__title {
+      width: max-content;
+      margin-left: 0.1rem;
+    }
+
+    .blog-toc__list {
+      padding-left: 0.15rem;
+    }
+  }
+</style>

--- a/src/components/BlogTableOfContents.astro
+++ b/src/components/BlogTableOfContents.astro
@@ -2,7 +2,7 @@
 export interface TableOfContentsItem {
   id: string
   text: string
-  level: 1 | 2 | 3
+  level: 1 | 2 | 3 | 4
 }
 
 export interface Props {
@@ -62,52 +62,68 @@ const { items } = Astro.props
       })
     }
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visibleEntries = entries
-          .filter((entry) => entry.isIntersecting)
-          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+    let ticking = false
+    const topOffset = 16
 
-        if (!visibleEntries.length) return
+    const updateActive = () => {
+      ticking = false
+      const currentY = window.scrollY + topOffset
+      let active = sections[0]
 
-        const active = sections.find(
-          (section) => section.target === visibleEntries[0].target
-        )
-
-        if (active) setActive(active.link)
-      },
-      {
-        rootMargin: '-18% 0px -72% 0px',
-        threshold: [0, 1],
+      for (const section of sections) {
+        const sectionTop =
+          section.target.getBoundingClientRect().top + window.scrollY
+        if (sectionTop <= currentY) {
+          active = section
+        } else {
+          break
+        }
       }
-    )
 
-    sections.forEach((section) => observer.observe(section.target))
-    setActive(sections[0].link)
+      setActive(active.link)
+    }
+
+    const requestUpdate = () => {
+      if (ticking) return
+      ticking = true
+      window.requestAnimationFrame(updateActive)
+    }
+
+    window.addEventListener('scroll', requestUpdate, { passive: true })
+    window.addEventListener('resize', requestUpdate)
+    window.addEventListener('hashchange', requestUpdate)
+    updateActive()
   })()
 </script>
 
 <style>
   .blog-toc {
     position: relative;
+    box-sizing: border-box;
     width: 100%;
+    padding: 1.1rem;
+    border: 1px solid rgba(124, 108, 242, 0.14);
+    border-radius: 18px;
     color: #6b6478;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(250, 247, 255, 0.72));
+    box-shadow: 0 18px 44px rgba(76, 60, 120, 0.08);
   }
 
   .blog-toc__title {
-    margin: 0 0 0.7rem;
+    margin: 0 0 0.85rem;
     color: #3f394d;
-    font-size: 0.78rem;
+    font-size: 1rem;
     font-weight: 700;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.04em;
   }
 
   .blog-toc__list {
+    --toc-rail-x: 0.425rem;
     position: relative;
     display: grid;
     gap: 0.15rem;
     margin: 0;
-    padding: 0.2rem 0 0.2rem 0.1rem;
+    padding: 0.2rem 0 0.2rem 0;
     list-style: none;
   }
 
@@ -116,9 +132,9 @@ const { items } = Astro.props
     position: absolute;
     top: 0.35rem;
     bottom: 0.35rem;
-    left: 0.42rem;
+    left: var(--toc-rail-x);
     width: 1px;
-    border-radius: 999px;
+    border-radius: 18px;
     background: rgba(124, 108, 242, 0.18);
   }
 
@@ -132,6 +148,30 @@ const { items } = Astro.props
 
   .blog-toc__item--level-3 {
     padding-left: 1.55rem;
+  }
+
+  .blog-toc__item--level-4 {
+    padding-left: 2.15rem;
+  }
+
+  .blog-toc__item--level-1 {
+    --toc-marker-color: rgba(248, 221, 94, 0.95);
+    --toc-marker-border: rgba(190, 153, 25, 0.55);
+  }
+
+  .blog-toc__item--level-2 {
+    --toc-marker-color: rgba(124, 108, 242, 0.82);
+    --toc-marker-border: rgba(124, 108, 242, 0.55);
+  }
+
+  .blog-toc__item--level-3 {
+    --toc-marker-color: rgba(133, 221, 176, 0.88);
+    --toc-marker-border: rgba(60, 151, 105, 0.5);
+  }
+
+  .blog-toc__item--level-4 {
+    --toc-marker-color: rgba(124, 108, 242, 0.72);
+    --toc-marker-border: rgba(124, 108, 242, 0.45);
   }
 
   .blog-toc__link {
@@ -158,10 +198,10 @@ const { items } = Astro.props
   .blog-toc__marker {
     position: relative;
     z-index: 1;
-    width: 0.45rem;
-    height: 0.45rem;
+    width: 0.5rem;
+    height: 0.5rem;
     margin: 0.48rem auto 0;
-    border: 1px solid rgba(124, 108, 242, 0.35);
+    border: 1px solid var(--toc-marker-border, rgba(124, 108, 242, 0.35));
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.92);
     transition:
@@ -173,8 +213,8 @@ const { items } = Astro.props
   .blog-toc__link:hover .blog-toc__marker,
   .blog-toc__link:focus-visible .blog-toc__marker,
   .blog-toc__link.is-active .blog-toc__marker {
-    border-color: rgba(124, 108, 242, 0.9);
-    background: #7c6cf2;
+    border-color: var(--toc-marker-border, rgba(124, 108, 242, 0.9));
+    background: var(--toc-marker-color, #7c6cf2);
     transform: scale(1.18);
   }
 
@@ -186,12 +226,18 @@ const { items } = Astro.props
     text-overflow: ellipsis;
   }
 
-  @media (max-width: 1180px) {
+  @media (max-width: 1320px) {
     .blog-toc {
-      width: 2.8rem;
+      position: relative;
+      right: 0;
+      z-index: 5;
+      flex: 0 0 auto;
+      width: 3rem;
+      margin-left: 0;
       padding: 0.6rem 0;
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.72);
+      border: 1px solid rgba(124, 108, 242, 0.14);
+      border-radius: 18px;
+      background: rgba(255, 255, 255, 0.78);
       box-shadow: 0 16px 36px rgba(76, 60, 120, 0.08);
       transition:
         width 180ms ease,
@@ -201,10 +247,11 @@ const { items } = Astro.props
 
     .blog-toc:hover,
     .blog-toc:focus-within {
-      width: min(17rem, calc(100vw - 2rem));
-      padding: 0.9rem 0.95rem;
+      width: min(300px, calc(100vw - 2rem));
+      padding: 1.1rem;
+      border-color: rgba(124, 108, 242, 0.14);
       border-radius: 18px;
-      background: rgba(255, 255, 255, 0.96);
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(250, 247, 255, 0.9));
     }
 
     .blog-toc__title,
@@ -220,13 +267,63 @@ const { items } = Astro.props
       opacity: 1;
     }
 
+    .blog-toc__list {
+      --toc-rail-x: 1.5rem;
+      padding-left: 0;
+    }
+
+    .blog-toc__item--level-2,
+    .blog-toc__item--level-3,
+    .blog-toc__item--level-4 {
+      padding-left: 0;
+    }
+
+    .blog-toc__link {
+      grid-template-columns: 3rem 0;
+      gap: 0;
+    }
+
     .blog-toc__title {
       width: max-content;
       margin-left: 0.1rem;
     }
 
-    .blog-toc__list {
-      padding-left: 0.15rem;
+    .blog-toc__text {
+      width: 0;
+      padding: 0;
+      white-space: nowrap;
+    }
+
+    .blog-toc:hover .blog-toc__list,
+    .blog-toc:focus-within .blog-toc__list {
+      --toc-rail-x: 0.425rem;
+    }
+
+    .blog-toc:hover .blog-toc__item--level-2,
+    .blog-toc:focus-within .blog-toc__item--level-2 {
+      padding-left: 0.85rem;
+    }
+
+    .blog-toc:hover .blog-toc__item--level-3,
+    .blog-toc:focus-within .blog-toc__item--level-3 {
+      padding-left: 1.55rem;
+    }
+
+    .blog-toc:hover .blog-toc__item--level-4,
+    .blog-toc:focus-within .blog-toc__item--level-4 {
+      padding-left: 2.15rem;
+    }
+
+    .blog-toc:hover .blog-toc__link,
+    .blog-toc:focus-within .blog-toc__link {
+      grid-template-columns: 0.85rem minmax(0, 1fr);
+      gap: 0.45rem;
+    }
+
+    .blog-toc:hover .blog-toc__text,
+    .blog-toc:focus-within .blog-toc__text {
+      width: auto;
+      padding: 0.18rem 0.35rem 0.18rem 0;
     }
   }
 </style>

--- a/src/components/NotionBlocks.astro
+++ b/src/components/NotionBlocks.astro
@@ -15,6 +15,7 @@ import Paragraph from './notion-blocks/Paragraph.astro'
 import Heading1 from './notion-blocks/Heading1.astro'
 import Heading2 from './notion-blocks/Heading2.astro'
 import Heading3 from './notion-blocks/Heading3.astro'
+import Heading4 from './notion-blocks/Heading4.astro'
 import TableOfContents from './notion-blocks/TableOfContents.astro'
 import Image from './notion-blocks/Image.astro'
 import Video from './notion-blocks/Video.astro'
@@ -33,6 +34,9 @@ import ToDo from './notion-blocks/ToDo.astro'
 import SyncedBlock from './notion-blocks/SyncedBlock.astro'
 import Toggle from './notion-blocks/Toggle.astro'
 import File from './notion-blocks/File.astro'
+import Pdf from './notion-blocks/Pdf.astro'
+import Tab from './notion-blocks/Tab.astro'
+import Unsupported from './notion-blocks/Unsupported.astro'
 import LinkToPage from './notion-blocks/LinkToPage.astro'
 
 export interface Props {
@@ -96,7 +100,7 @@ const blocks = rawBlocks.reduce((arr, block: interfaces.Block, i: number) => {
 let headings = rawHeadings
 if (isRoot) {
   headings = blocks.filter((b: interfaces.Block) =>
-    ['heading_1', 'heading_2', 'heading_3'].includes(b.Type)
+    ['heading_1', 'heading_2', 'heading_3', 'heading_4'].includes(b.Type)
   )
 }
 
@@ -140,6 +144,8 @@ const bookmarkURLMap = await buildURLToHTMLMap(bookmarkURLs)
         return <Heading2 block={block} headings={headings} />
       case 'heading_3':
         return <Heading3 block={block} headings={headings} />
+      case 'heading_4':
+        return <Heading4 block={block} headings={headings} />
       case 'table_of_contents':
         return <TableOfContents block={block} headings={headings} />
       case 'image':
@@ -179,9 +185,15 @@ const bookmarkURLMap = await buildURLToHTMLMap(bookmarkURLs)
         return <Toggle block={block} headings={headings} />
       case 'file':
         return <File block={block} />
+      case 'pdf':
+        return <Pdf block={block} />
+      case 'tab':
+        return <Tab block={block} headings={headings} />
+      case 'unsupported':
+        return <Unsupported block={block} />
       case 'link_to_page':
         return <LinkToPage block={block} />
     }
-    return null
+    return <Unsupported block={block} />
   })
 }

--- a/src/components/notion-blocks/Heading4.astro
+++ b/src/components/notion-blocks/Heading4.astro
@@ -1,0 +1,85 @@
+---
+import * as interfaces from '../../lib/interfaces.ts'
+import { buildHeadingId } from '../../lib/blog-helpers.ts'
+import RichText from './RichText.astro'
+import NotionBlocks from '../NotionBlocks.astro'
+
+export interface Props {
+  block: interfaces.Block
+  headings: interfaces.Block[]
+}
+
+const { block, headings } = Astro.props
+
+const id = buildHeadingId(block.Heading4)
+---
+
+{
+  block.Heading4.IsToggleable ? (
+    <details class="toggle">
+      <summary>
+        <a href={`#${id}`} id={id}>
+          <h6>
+            {block.Heading4.RichTexts.map((richText: interfaces.RichText) => (
+              <RichText richText={richText} />
+            ))}
+          </h6>
+        </a>
+      </summary>
+      <div>
+        {block.Heading4.Children && (
+          <NotionBlocks blocks={block.Heading4.Children} headings={headings} />
+        )}
+      </div>
+    </details>
+  ) : (
+    <a href={`#${id}`} id={id}>
+      <h6>
+        {block.Heading4.RichTexts.map((richText: interfaces.RichText) => (
+          <RichText richText={richText} />
+        ))}
+      </h6>
+    </a>
+  )
+}
+
+<style>
+  h6 {
+    margin: 0.8em 0 0.25em;
+    color: var(--fg);
+    font-size: 1.08rem;
+    line-height: 1.3;
+  }
+
+  @media (max-width: 640px) {
+    h6 {
+      font-size: 1rem;
+    }
+  }
+
+  .toggle {
+    margin: 1.2rem 0 0;
+  }
+
+  @media (max-width: 640px) {
+    .toggle {
+      margin: 1.1rem 0 0;
+    }
+  }
+
+  .toggle > summary {
+    cursor: pointer;
+  }
+
+  .toggle > summary > a {
+    display: inline;
+  }
+
+  .toggle > summary > a > h6 {
+    display: inline;
+  }
+
+  .toggle > div {
+    margin-left: 1em;
+  }
+</style>

--- a/src/components/notion-blocks/Mention.astro
+++ b/src/components/notion-blocks/Mention.astro
@@ -1,0 +1,92 @@
+---
+import type { Post } from '../../lib/interfaces.ts'
+import { getPostByPageId } from '../../lib/notion/client'
+import { getPostLink } from '../../lib/blog-helpers.ts'
+import arrow from '../../images/icon-arrow-link.svg'
+
+export interface Props {
+  pageId: string
+  label?: string
+  href?: string
+}
+
+const { pageId, label = 'Linked page', href } = Astro.props
+
+let post: Post | null = null
+if (pageId) {
+  post = await getPostByPageId(pageId)
+}
+
+const icon = post?.Icon
+const emojiIcon = icon && 'Emoji' in icon ? icon.Emoji : null
+const imageIcon = icon && 'Url' in icon ? icon.Url : null
+const linkHref = post ? getPostLink(post.Slug) : href
+const title = post?.Title || label
+---
+
+<a
+  href={linkHref}
+  class:list={["mention-link", !linkHref && "mention-link--not-found"]}
+  target={!post && href ? '_blank' : undefined}
+  rel={!post && href ? 'noopener noreferrer' : undefined}
+>
+  <span class="mention-link__icon">
+    {
+      imageIcon ? (
+        <img src={imageIcon} class="mention-link__notion-icon" alt="" />
+      ) : (
+        emojiIcon || '📄'
+      )
+    }
+    <img src={arrow.src} class="mention-link__arrow" alt="" />
+  </span>
+  <span class="mention-link__text">{title}</span>
+</a>
+
+<style>
+  .mention-link {
+    display: inline-flex;
+    align-items: flex-start;
+    gap: 0.35rem;
+    color: var(--fg);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .mention-link--not-found {
+    opacity: 0.65;
+    pointer-events: none;
+  }
+
+  .mention-link__icon {
+    position: relative;
+    flex-shrink: 0;
+    height: fit-content;
+    line-height: 1.35;
+  }
+
+  .mention-link__notion-icon {
+    width: 1.3em;
+    height: 1.3em;
+    object-fit: cover;
+    border-radius: 0.25rem;
+    vertical-align: -0.2em;
+  }
+
+  .mention-link__arrow {
+    position: absolute;
+    right: -0.2em;
+    bottom: -0.05em;
+    display: block;
+    width: 8px;
+    height: 8px;
+  }
+
+  .mention-link__text {
+    color: var(--fg);
+    font-weight: 500;
+    text-decoration: underline;
+    text-decoration-thickness: 0.06em;
+    text-underline-offset: 0.16em;
+  }
+</style>

--- a/src/components/notion-blocks/Pdf.astro
+++ b/src/components/notion-blocks/Pdf.astro
@@ -1,0 +1,86 @@
+---
+import * as interfaces from '../../lib/interfaces'
+import { filePath } from '../../lib/blog-helpers'
+import Caption from './Caption.astro'
+
+export interface Props {
+  block: interfaces.Block
+}
+
+const { block } = Astro.props
+
+let url: URL | null = null
+try {
+  url = new URL(block.Pdf?.External?.Url || block.Pdf?.File?.Url)
+} catch (err) {
+  console.error(`Invalid PDF URL. error: ${err}`)
+}
+
+const filename = url ? decodeURIComponent(url.pathname.split('/').slice(-1)[0]) : ''
+const href = url ? (block.Pdf.External ? url.toString() : filePath(url)) : ''
+---
+
+<div class="pdf">
+  {
+    url && (
+      <>
+        <a class="pdfLink" href={href} target="_blank" rel="noopener noreferrer">
+          <img src="https://www.notion.so/icons/pdf_gray.svg" alt="" loading="lazy" />
+          <span>{filename || 'PDF'}</span>
+        </a>
+        <iframe src={href} title={filename || 'PDF preview'} loading="lazy" />
+      </>
+    )
+  }
+  <Caption richTexts={block.Pdf.Caption} />
+</div>
+
+<style>
+  .pdf {
+    margin: 0.9rem 0;
+  }
+
+  .pdfLink {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    max-width: 100%;
+    margin-bottom: 0.55rem;
+    padding: 0.45rem 0.55rem;
+    border-radius: var(--radius);
+    color: var(--fg);
+    font-weight: 500;
+    line-height: 1.4rem;
+    text-decoration: none;
+  }
+
+  .pdfLink:hover {
+    background-color: rgba(235, 236, 237, 0.7);
+  }
+
+  .pdfLink img {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex: 0 0 auto;
+  }
+
+  .pdfLink span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .pdf iframe {
+    width: 100%;
+    min-height: min(70vh, 720px);
+    border: 1px solid rgba(55, 53, 47, 0.16);
+    border-radius: 12px;
+    background: rgba(247, 246, 243, 0.6);
+  }
+
+  @media (max-width: 640px) {
+    .pdf iframe {
+      min-height: 420px;
+    }
+  }
+</style>

--- a/src/components/notion-blocks/RichText.astro
+++ b/src/components/notion-blocks/RichText.astro
@@ -8,6 +8,7 @@ import Underline from './annotations/Underline.astro'
 import Color from './annotations/Color.astro'
 import Code from './annotations/Code.astro'
 import Anchor from './annotations/Anchor.astro'
+import Mention from './Mention.astro'
 
 export interface Props {
   richText: RichText
@@ -48,6 +49,18 @@ const { richText } = Astro.props
                     )}
                   />
                 )
+              }
+              {
+                richText.Mention?.Page && (
+                  <Mention
+                    pageId={richText.Mention.Page.Id}
+                    label={richText.PlainText}
+                    href={richText.Href}
+                  />
+                )
+              }
+              {
+                richText.Mention && !richText.Mention.Page && richText.PlainText
               }
             </Bold>
           </Italic>

--- a/src/components/notion-blocks/Tab.astro
+++ b/src/components/notion-blocks/Tab.astro
@@ -1,0 +1,110 @@
+---
+import * as interfaces from '../../lib/interfaces.ts'
+import NotionBlocks from '../NotionBlocks.astro'
+import RichText from './RichText.astro'
+
+export interface Props {
+  block: interfaces.Block
+  headings: interfaces.Block[]
+}
+
+const { block, headings } = Astro.props
+const tabs = (block.Tab?.Children || []).filter(
+  (child: interfaces.Block) => child.Type === 'paragraph' && child.Paragraph
+)
+const groupName = `tab-${block.Id}`
+---
+
+{
+  tabs.length > 0 && (
+    <div class="tabs">
+      <div class="tabLabels" role="tablist">
+        {tabs.map((tab: interfaces.Block, index: number) => {
+          const id = `${groupName}-${index}`
+          return (
+            <label class="tabLabel" for={id} role="tab">
+              <input id={id} type="radio" name={groupName} checked={index === 0} />
+              <span>
+                {tab.Paragraph.RichTexts.map((richText: interfaces.RichText) => (
+                  <RichText richText={richText} />
+                ))}
+              </span>
+            </label>
+          )
+        })}
+      </div>
+      <div class="tabPanels">
+        {tabs.map((tab: interfaces.Block, index: number) => (
+          <section class="tabPanel" data-tab-panel={index}>
+            {tab.Paragraph.Children && (
+              <NotionBlocks blocks={tab.Paragraph.Children} headings={headings} />
+            )}
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+<style>
+  .tabs {
+    margin: 1rem 0;
+    border: 1px solid rgba(55, 53, 47, 0.12);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.72);
+    overflow: hidden;
+  }
+
+  .tabLabels {
+    display: flex;
+    gap: 0.35rem;
+    overflow-x: auto;
+    padding: 0.55rem 0.6rem 0;
+    border-bottom: 1px solid rgba(55, 53, 47, 0.1);
+  }
+
+  .tabLabel {
+    flex: 0 0 auto;
+  }
+
+  .tabLabel input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .tabLabel span {
+    display: block;
+    padding: 0.45rem 0.75rem;
+    border-radius: 10px 10px 0 0;
+    color: #6b6478;
+    cursor: pointer;
+    font-size: 0.92rem;
+    line-height: 1.35;
+  }
+
+  .tabLabel input:checked + span {
+    color: #373241;
+    background: rgba(250, 247, 255, 0.95);
+    box-shadow: inset 0 -2px 0 rgba(124, 108, 242, 0.65);
+  }
+
+  .tabPanels {
+    padding: 0.8rem 1rem 1rem;
+  }
+
+  .tabPanel {
+    display: none;
+  }
+
+  .tabs:has(.tabLabel:nth-child(1) input:checked) .tabPanel:nth-child(1),
+  .tabs:has(.tabLabel:nth-child(2) input:checked) .tabPanel:nth-child(2),
+  .tabs:has(.tabLabel:nth-child(3) input:checked) .tabPanel:nth-child(3),
+  .tabs:has(.tabLabel:nth-child(4) input:checked) .tabPanel:nth-child(4),
+  .tabs:has(.tabLabel:nth-child(5) input:checked) .tabPanel:nth-child(5),
+  .tabs:has(.tabLabel:nth-child(6) input:checked) .tabPanel:nth-child(6),
+  .tabs:has(.tabLabel:nth-child(7) input:checked) .tabPanel:nth-child(7),
+  .tabs:has(.tabLabel:nth-child(8) input:checked) .tabPanel:nth-child(8) {
+    display: block;
+  }
+</style>

--- a/src/components/notion-blocks/Table.astro
+++ b/src/components/notion-blocks/Table.astro
@@ -7,33 +7,136 @@ export interface Props {
 }
 
 const { block } = Astro.props
+
+type RenderCell = {
+  cell: interfaces.TableCell
+  colIndex: number
+  rowIndex: number
+  colSpan: number
+  rowSpan: number
+  hidden: boolean
+}
+
+const isEmptyCell = (cell: interfaces.TableCell) =>
+  cell.RichTexts.every((richText) => !richText.PlainText.trim())
+
+const renderRows: RenderCell[][] = block.Table.Rows.map((row, rowIndex) =>
+  row.Cells.map((cell, colIndex) => ({
+    cell,
+    colIndex,
+    rowIndex,
+    colSpan: cell.ColSpan || 1,
+    rowSpan: cell.RowSpan || 1,
+    hidden: false,
+  }))
+)
+
+const hasExplicitSpans = renderRows.some((row) =>
+  row.some((cell) => cell.colSpan > 1 || cell.rowSpan > 1)
+)
+
+const visibleCellCovering = (row: RenderCell[], colIndex: number) =>
+  row.find(
+    (cell) =>
+      !cell.hidden &&
+      cell.colIndex <= colIndex &&
+      colIndex < cell.colIndex + cell.colSpan
+  )
+
+const visibleSourceReachingRow = (rowIndex: number, colIndex: number) => {
+  for (let i = rowIndex - 1; i >= 0; i--) {
+    const source = visibleCellCovering(renderRows[i], colIndex)
+    if (
+      source &&
+      !isEmptyCell(source.cell) &&
+      source.rowIndex + source.rowSpan === rowIndex
+    ) {
+      return source
+    }
+  }
+  return undefined
+}
+
+if (!hasExplicitSpans) {
+  renderRows.forEach((row) => {
+    row.forEach((renderCell, columnIndex) => {
+      if (renderCell.hidden || !isEmptyCell(renderCell.cell)) {
+        return
+      }
+
+      const prevCell = row[columnIndex - 1]
+      if (prevCell && !prevCell.hidden && !isEmptyCell(prevCell.cell)) {
+        prevCell.colSpan += 1
+        renderCell.hidden = true
+      }
+    })
+  })
+
+  renderRows.forEach((row, rowIndex) => {
+    if (rowIndex === 0) {
+      return
+    }
+
+    const extendedSources = new Set<RenderCell>()
+
+    row.forEach((renderCell) => {
+      if (renderCell.hidden || !isEmptyCell(renderCell.cell)) {
+        return
+      }
+
+      const source = visibleSourceReachingRow(rowIndex, renderCell.colIndex)
+      if (!source || extendedSources.has(source)) {
+        return
+      }
+      const cellsToHide: RenderCell[] = []
+      for (
+        let colIndex = source.colIndex;
+        colIndex < source.colIndex + source.colSpan;
+        colIndex++
+      ) {
+        const coveredCell = visibleCellCovering(row, colIndex)
+        if (!coveredCell || !isEmptyCell(coveredCell.cell)) {
+          return
+        }
+        if (!cellsToHide.includes(coveredCell)) {
+          cellsToHide.push(coveredCell)
+        }
+      }
+
+      source.rowSpan += 1
+      extendedSources.add(source)
+      cellsToHide.forEach((cell) => {
+        cell.hidden = true
+      })
+    })
+  })
+}
+
 ---
 
 <div class="table">
   <table>
     <tbody>
       {
-        block.Table.Rows.map((tableRow: interfaces.TableRow, j: number) => (
+        renderRows.map((tableRow: RenderCell[], j: number) => (
           <tr>
-            {tableRow.Cells.map((cell: interfaces.TableCell, i: number) => {
-              if (
+            {tableRow.map((renderCell: RenderCell, i: number) => {
+              if (renderCell.hidden) {
+                return null
+              }
+
+              const Tag =
                 (block.Table.HasRowHeader && i === 0) ||
                 (block.Table.HasColumnHeader && j === 0)
-              ) {
-                return (
-                  <th>
-                    {cell.RichTexts.map((richText: interfaces.RichText) => (
-                      <RichText richText={richText} />
-                    ))}
-                  </th>
-                )
-              }
+                  ? 'th'
+                  : 'td'
+
               return (
-                <td>
-                  {cell.RichTexts.map((richText: interfaces.RichText) => (
+                <Tag colspan={renderCell.colSpan} rowspan={renderCell.rowSpan}>
+                  {renderCell.cell.RichTexts.map((richText: interfaces.RichText) => (
                     <RichText richText={richText} />
                   ))}
-                </td>
+                </Tag>
               )
             })}
           </tr>
@@ -51,11 +154,15 @@ const { block } = Astro.props
   .table table {
     margin: 0.6rem 0;
     border-collapse: collapse;
+    width: max-content;
+    max-width: 100%;
+    table-layout: auto;
   }
 
   .table th,
   .table td {
-    min-width: 120px;
+    min-width: 0;
+    max-width: min(32rem, 72vw);
     border: 1px solid rgba(55, 53, 47, 0.16);
     padding: 0.45rem 0.65rem;
     font-weight: normal;

--- a/src/components/notion-blocks/TableOfContents.astro
+++ b/src/components/notion-blocks/TableOfContents.astro
@@ -16,13 +16,18 @@ const { block, headings } = Astro.props
   {
     headings.map((headingBlock: interfaces.Block) => {
       const heading =
-        headingBlock.Heading1 || headingBlock.Heading2 || headingBlock.Heading3
+        headingBlock.Heading1 ||
+        headingBlock.Heading2 ||
+        headingBlock.Heading3 ||
+        headingBlock.Heading4
 
       let indentClass = ''
       if (headingBlock.Type === 'heading_2') {
         indentClass = 'indent-1'
       } else if (headingBlock.Type === 'heading_3') {
         indentClass = 'indent-2'
+      } else if (headingBlock.Type === 'heading_4') {
+        indentClass = 'indent-3'
       }
 
       return (
@@ -58,5 +63,8 @@ const { block, headings } = Astro.props
   }
   .table-of-contents > a.indent-2 {
     padding-left: 3rem;
+  }
+  .table-of-contents > a.indent-3 {
+    padding-left: 4.5rem;
   }
 </style>

--- a/src/components/notion-blocks/Unsupported.astro
+++ b/src/components/notion-blocks/Unsupported.astro
@@ -1,0 +1,37 @@
+---
+import * as interfaces from '../../lib/interfaces'
+
+export interface Props {
+  block: interfaces.Block
+}
+
+const { block } = Astro.props
+const blockType = block.Unsupported?.BlockType || block.Type || 'unknown'
+---
+
+<div class="unsupported" role="note">
+  <span>未対応ブロック</span>
+  <code>{blockType}</code>
+</div>
+
+<style>
+  .unsupported {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin: 0.75rem 0;
+    padding: 0.7rem 0.85rem;
+    border: 1px dashed rgba(124, 108, 242, 0.35);
+    border-radius: 12px;
+    color: #6b6478;
+    background: rgba(250, 247, 255, 0.72);
+    font-size: 0.9rem;
+  }
+
+  .unsupported code {
+    padding: 0.1rem 0.35rem;
+    border-radius: 6px;
+    color: #4f43c7;
+    background: rgba(124, 108, 242, 0.1);
+  }
+</style>

--- a/src/components/notion-blocks/annotations/Anchor.astro
+++ b/src/components/notion-blocks/annotations/Anchor.astro
@@ -6,10 +6,11 @@ export interface Props {
 }
 
 const { richText } = Astro.props
+const shouldWrap = richText.Href && !richText.Mention?.Page
 ---
 
 {
-  richText.Href ? (
+  shouldWrap ? (
     <a href={richText.Href}>
       <slot />
     </a>

--- a/src/lib/blog-helpers.ts
+++ b/src/lib/blog-helpers.ts
@@ -5,6 +5,7 @@ import type {
   Heading1,
   Heading2,
   Heading3,
+  Heading4,
   RichText,
   Column,
 } from './interfaces'
@@ -60,6 +61,10 @@ export const extractTargetBlocks = (
       } else if (block.Heading3 && block.Heading3.Children) {
         acc = acc.concat(
           extractTargetBlocks(blockType, block.Heading3.Children)
+        )
+      } else if (block.Heading4 && block.Heading4.Children) {
+        acc = acc.concat(
+          extractTargetBlocks(blockType, block.Heading4.Children)
         )
       } else if (block.Quote && block.Quote.Children) {
         acc = acc.concat(extractTargetBlocks(blockType, block.Quote.Children))
@@ -164,7 +169,9 @@ export const getDateStr = (date: string) => {
   return y + '-' + m + '-' + d
 }
 
-export const buildHeadingId = (heading: Heading1 | Heading2 | Heading3) => {
+export const buildHeadingId = (
+  heading: Heading1 | Heading2 | Heading3 | Heading4
+) => {
   return heading.RichTexts.map((richText: RichText) => {
     if (!richText.Text) {
       return ''

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -20,11 +20,13 @@ export interface Block {
   Heading1?: Heading1
   Heading2?: Heading2
   Heading3?: Heading3
+  Heading4?: Heading4
   BulletedListItem?: BulletedListItem
   NumberedListItem?: NumberedListItem
   ToDo?: ToDo
   Image?: Image
   File?: File
+  Pdf?: File
   Code?: Code
   Quote?: Quote
   Equation?: Equation
@@ -39,6 +41,8 @@ export interface Block {
   ColumnList?: ColumnList
   TableOfContents?: TableOfContents
   LinkToPage?: LinkToPage
+  Tab?: Tab
+  Unsupported?: Unsupported
 }
 
 export interface Paragraph {
@@ -62,6 +66,13 @@ export interface Heading2 {
 }
 
 export interface Heading3 {
+  RichTexts: RichText[]
+  Color: string
+  IsToggleable: boolean
+  Children?: Block[]
+}
+
+export interface Heading4 {
   RichTexts: RichText[]
   Color: string
   IsToggleable: boolean
@@ -184,6 +195,16 @@ export interface TableRow {
 
 export interface TableCell {
   RichTexts: RichText[]
+  ColSpan?: number
+  RowSpan?: number
+}
+
+export interface Tab {
+  Children: Block[]
+}
+
+export interface Unsupported {
+  BlockType: string
 }
 
 export interface ColumnList {
@@ -212,6 +233,7 @@ export interface RichText {
   PlainText: string
   Href?: string
   Equation?: Equation
+  Mention?: Mention
 }
 
 export interface Text {
@@ -247,4 +269,15 @@ export interface SelectProperty {
 export interface LinkToPage {
   Type: string
   PageId: string
+}
+
+export interface Mention {
+  Type: string
+  Page?: Reference
+  Database?: Reference
+  LinkPreview?: LinkPreview
+}
+
+export interface Reference {
+  Id: string
 }

--- a/src/lib/notion/client.ts
+++ b/src/lib/notion/client.ts
@@ -17,6 +17,7 @@ import type {
   Heading1,
   Heading2,
   Heading3,
+  Heading4,
   BulletedListItem,
   NumberedListItem,
   ToDo,
@@ -46,6 +47,10 @@ import type {
   Emoji,
   FileObject,
   LinkToPage,
+  Mention,
+  Reference,
+  Tab,
+  Unsupported,
 } from '../interfaces'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 import { Client } from '@notionhq/client'
@@ -288,10 +293,18 @@ export async function getAllBlocksByBlockId(blockId: string): Promise<Block[]> {
       block.HasChildren
     ) {
       block.Heading3.Children = await getAllBlocksByBlockId(block.Id)
+    } else if (
+      block.Type === 'heading_4' &&
+      block.Heading4 &&
+      block.HasChildren
+    ) {
+      block.Heading4.Children = await getAllBlocksByBlockId(block.Id)
     } else if (block.Type === 'quote' && block.Quote && block.HasChildren) {
       block.Quote.Children = await getAllBlocksByBlockId(block.Id)
     } else if (block.Type === 'callout' && block.Callout && block.HasChildren) {
       block.Callout.Children = await getAllBlocksByBlockId(block.Id)
+    } else if (block.Type === 'tab' && block.Tab && block.HasChildren) {
+      block.Tab.Children = await getAllBlocksByBlockId(block.Id)
     }
   }
 
@@ -410,6 +423,16 @@ function _buildBlock(blockObject: responses.BlockObject): Block {
         block.Heading3 = heading3
       }
       break
+    case 'heading_4':
+      if (blockObject.heading_4) {
+        const heading4: Heading4 = {
+          RichTexts: blockObject.heading_4.rich_text.map(_buildRichText),
+          Color: blockObject.heading_4.color,
+          IsToggleable: blockObject.heading_4.is_toggleable,
+        }
+        block.Heading4 = heading4
+      }
+      break
     case 'bulleted_list_item':
       if (blockObject.bulleted_list_item) {
         const bulletedListItem: BulletedListItem = {
@@ -493,6 +516,23 @@ function _buildBlock(blockObject: responses.BlockObject): Block {
           }
         }
         block.File = file
+      }
+      break
+    case 'pdf':
+      if (blockObject.pdf) {
+        const pdf: File = {
+          Caption: blockObject.pdf.caption?.map(_buildRichText) || [],
+          Type: blockObject.pdf.type,
+        }
+        if (blockObject.pdf.type === 'external' && blockObject.pdf.external) {
+          pdf.External = { Url: blockObject.pdf.external.url }
+        } else if (blockObject.pdf.type === 'file' && blockObject.pdf.file) {
+          pdf.File = {
+            Url: blockObject.pdf.file.url,
+            ExpiryTime: blockObject.pdf.file.expiry_time,
+          }
+        }
+        block.Pdf = pdf
       }
       break
     case 'code':
@@ -623,6 +663,20 @@ function _buildBlock(blockObject: responses.BlockObject): Block {
         block.LinkToPage = linkToPage
       }
       break
+    case 'tab': {
+      const tab: Tab = {
+        Children: [],
+      }
+      block.Tab = tab
+      break
+    }
+    case 'unsupported': {
+      const unsupported: Unsupported = {
+        BlockType: blockObject.unsupported?.block_type || 'unknown',
+      }
+      block.Unsupported = unsupported
+      break
+    }
   }
 
   return block
@@ -665,6 +719,9 @@ async function _getTableRows(blockId: string): Promise<TableRow[]> {
       const cells: TableCell[] = blockObject.table_row.cells.map((cell) => {
         const tableCell: TableCell = {
           RichTexts: cell.map(_buildRichText),
+          ColSpan:
+            cell.col_span || cell.colspan || cell.column_span || undefined,
+          RowSpan: cell.row_span || cell.rowspan || undefined,
         }
 
         return tableCell
@@ -820,6 +877,34 @@ function _buildRichText(richTextObject: responses.RichTextObject): RichText {
       Expression: richTextObject.equation.expression,
     }
     richText.Equation = equation
+  } else if (richTextObject.type === 'mention' && richTextObject.mention) {
+    const mention: Mention = {
+      Type: richTextObject.mention.type,
+    }
+
+    if (richTextObject.mention.type === 'page' && richTextObject.mention.page) {
+      const reference: Reference = {
+        Id: richTextObject.mention.page.id,
+      }
+      mention.Page = reference
+    } else if (
+      richTextObject.mention.type === 'database' &&
+      richTextObject.mention.database
+    ) {
+      const reference: Reference = {
+        Id: richTextObject.mention.database.id,
+      }
+      mention.Database = reference
+    } else if (
+      richTextObject.mention.type === 'link_preview' &&
+      richTextObject.mention.link_preview
+    ) {
+      mention.LinkPreview = {
+        Url: richTextObject.mention.link_preview.url,
+      }
+    }
+
+    richText.Mention = mention
   }
 
   return richText

--- a/src/lib/notion/responses.ts
+++ b/src/lib/notion/responses.ts
@@ -324,6 +324,7 @@ export interface BlockObject {
   heading_1?: Heading
   heading_2?: Heading
   heading_3?: Heading
+  heading_4?: Heading
   callout?: Callout
   quote?: Quote
   bulleted_list_item?: ListItem
@@ -351,6 +352,8 @@ export interface BlockObject {
   synced_block?: SyncedBlock
   table?: Table
   table_row?: TableRow
+  tab?: Record<string, never>
+  unsupported?: Unsupported
 }
 
 interface Paragraph {
@@ -457,5 +460,17 @@ interface Table {
 }
 
 interface TableRow {
-  cells: RichTextObject[][]
+  cells: TableCellObject[]
+}
+
+type TableCellObject = RichTextObject[] & {
+  col_span?: number
+  colspan?: number
+  column_span?: number
+  row_span?: number
+  rowspan?: number
+}
+
+interface Unsupported {
+  block_type: string
 }

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -52,11 +52,12 @@ const [blocks, allPosts, rankedPosts, recentPosts, tags, postsHavingSameTag] =
 
 const fileAtacchedBlocks = extractTargetBlocks('image', blocks)
   .concat(extractTargetBlocks('file', blocks))
+  .concat(extractTargetBlocks('pdf', blocks))
   .filter((block) => {
     if (!block) {
       return false
     }
-    const imageOrFile = block.Image || block.File
+    const imageOrFile = block.Image || block.File || block.Pdf
     return imageOrFile && imageOrFile.File && imageOrFile.File.Url
   })
 
@@ -64,7 +65,7 @@ const fileAtacchedBlocks = extractTargetBlocks('image', blocks)
 await Promise.all(
   fileAtacchedBlocks
     .map(async (block) => {
-      const expiryTime = (block.Image || block.File).File.ExpiryTime
+      const expiryTime = (block.Image || block.File || block.Pdf).File.ExpiryTime
       if (Date.parse(expiryTime) > Date.now()) {
         return Promise.resolve(block)
       }
@@ -74,7 +75,7 @@ await Promise.all(
       promise.then((block) => {
         let url!: URL
         try {
-          url = new URL((block.Image || block.File).File.Url)
+          url = new URL((block.Image || block.File || block.Pdf).File.Url)
         } catch {
           console.log('Invalid file URL')
           return Promise.reject()
@@ -92,18 +93,20 @@ const nextPost = allPosts[currentPostIndex - 1]
 type TableOfContentsItem = {
   id: string
   text: string
-  level: 1 | 2 | 3
+  level: 1 | 2 | 3 | 4
 }
 
 const collectHeadingItems = (
   targetBlocks: interfaces.Block[]
 ): TableOfContentsItem[] => {
   return targetBlocks.flatMap((block) => {
-    const heading = block.Heading1 || block.Heading2 || block.Heading3
+    const heading =
+      block.Heading1 || block.Heading2 || block.Heading3 || block.Heading4
     const children =
       block.Heading1?.Children ||
       block.Heading2?.Children ||
       block.Heading3?.Children ||
+      block.Heading4?.Children ||
       block.Paragraph?.Children ||
       block.Quote?.Children ||
       block.Callout?.Children ||
@@ -126,7 +129,13 @@ const collectHeadingItems = (
     }
 
     const level =
-      block.Type === 'heading_1' ? 1 : block.Type === 'heading_2' ? 2 : 3
+      block.Type === 'heading_1'
+        ? 1
+        : block.Type === 'heading_2'
+          ? 2
+          : block.Type === 'heading_3'
+            ? 3
+            : 4
 
     return [
       {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -15,6 +15,7 @@ import {
   getPostLink,
   filePath,
   extractTargetBlocks,
+  buildHeadingId,
 } from '../../lib/blog-helpers.ts'
 import Layout from '../../layouts/Layout.astro'
 import PostDate from '../../components/PostDate.astro'
@@ -24,6 +25,7 @@ import PostBody from '../../components/PostBody.astro'
 import PostRelativeLink from '../../components/PostRelativeLink.astro'
 import BlogPostsLink from '../../components/BlogPostsLink.astro'
 import BlogTagsLink from '../../components/BlogTagsLink.astro'
+import BlogTableOfContents from '../../components/BlogTableOfContents.astro'
 import styles from '../../styles/blog.module.css'
 
 export async function getStaticPaths() {
@@ -87,6 +89,58 @@ const currentPostIndex = allPosts.findIndex((post) => post.Slug === slug)
 const prevPost = allPosts[currentPostIndex + 1]
 const nextPost = allPosts[currentPostIndex - 1]
 
+type TableOfContentsItem = {
+  id: string
+  text: string
+  level: 1 | 2 | 3
+}
+
+const collectHeadingItems = (
+  targetBlocks: interfaces.Block[]
+): TableOfContentsItem[] => {
+  return targetBlocks.flatMap((block) => {
+    const heading = block.Heading1 || block.Heading2 || block.Heading3
+    const children =
+      block.Heading1?.Children ||
+      block.Heading2?.Children ||
+      block.Heading3?.Children ||
+      block.Paragraph?.Children ||
+      block.Quote?.Children ||
+      block.Callout?.Children ||
+      block.SyncedBlock?.Children ||
+      block.Toggle?.Children ||
+      []
+
+    const childItems = collectHeadingItems(children)
+
+    if (!heading) {
+      return childItems
+    }
+
+    const text = heading.RichTexts.map((richText) => richText.PlainText)
+      .join('')
+      .trim()
+
+    if (!text) {
+      return childItems
+    }
+
+    const level =
+      block.Type === 'heading_1' ? 1 : block.Type === 'heading_2' ? 2 : 3
+
+    return [
+      {
+        id: buildHeadingId(heading),
+        text,
+        level,
+      },
+      ...childItems,
+    ]
+  })
+}
+
+const tocItems = collectHeadingItems(blocks)
+
 let ogImage = ''
 if (post.FeaturedImage && post.FeaturedImage.Url) {
   ogImage = new URL(filePath(new URL(post.FeaturedImage.Url)), Astro.site)
@@ -99,8 +153,24 @@ if (post.FeaturedImage && post.FeaturedImage.Url) {
   path={getPostLink(post.Slug)}
   ogImage={ogImage}
 >
-  <div class={styles.container}>
-    <main>
+  <div
+    class={`${styles.container} ${
+      tocItems.length > 0 ? styles.withToc : styles.withoutToc
+    }`}
+  >
+    <aside class={styles.sidebar}>
+      <BlogPostsLink
+        heading="同じカテゴリの記事"
+        posts={postsHavingSameTag.filter(
+          (p: interfaces.Post) => p.Slug !== post.Slug
+        )}
+      />
+      <BlogPostsLink heading="おすすめ" posts={rankedPosts} />
+      <BlogPostsLink heading="新着記事" posts={recentPosts} />
+      <BlogTagsLink heading="カテゴリ" tags={tags} />
+    </aside>
+
+    <main class={styles.article}>
       <div class={styles.post}>
         <PostDate post={post} />
         <PostTags post={post} />
@@ -114,16 +184,12 @@ if (post.FeaturedImage && post.FeaturedImage.Url) {
       </div>
     </main>
 
-    <aside>
-      <BlogPostsLink
-        heading="同じカテゴリの記事"
-        posts={postsHavingSameTag.filter(
-          (p: interfaces.Post) => p.Slug !== post.Slug
-        )}
-      />
-      <BlogPostsLink heading="おすすめ" posts={rankedPosts} />
-      <BlogPostsLink heading="新着記事" posts={recentPosts} />
-      <BlogTagsLink heading="カテゴリ" tags={tags} />
-    </aside>
+    {
+      tocItems.length > 0 && (
+        <aside class={styles.tocSidebar}>
+          <BlogTableOfContents items={tocItems} />
+        </aside>
+      )
+    }
   </div>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,22 +5,6 @@ const shopUrl = 'https://suzuri.jp/crossn/digital_products'
 
 const products = [
   {
-    title: 'Themes / Goal Management',
-    eyebrow: '目標管理',
-    description:
-      'やりたいことを、日々の行動へほどいていくNotionテンプレート。迷子になりがちな目標を、見返せる形に整えます。',
-    image: '/page/tmg-fb.png',
-    href: 'https://suzuri.jp/crossn/digital_products/4871',
-  },
-  {
-    title: 'Themes / Goal Management Lite',
-    eyebrow: '目標管理 Lite',
-    description:
-      'Goal Managementの考え方を、より軽く始められる形にしたLite版。まず小さく整えたい人向けです。',
-    image: '/templates/themes-goal-management-lite.png',
-    href: shopUrl,
-  },
-  {
     title: 'Spark Brain OS Pro',
     eyebrow: 'Brain OS',
     description:
@@ -37,6 +21,14 @@ const products = [
     href: shopUrl,
   },
   {
+    title: 'Color Palette',
+    eyebrow: 'Notion Tools',
+    description:
+      'Notionページづくりの色選びを助けるパレット。整える時間そのものが少し楽しくなる道具です。',
+    image: '/page/palette.png',
+    href: 'https://suzuri.jp/crossn/digital_products/7685',
+  },
+  {
     title: 'Font Chooser',
     eyebrow: 'Notion Tools',
     description:
@@ -45,12 +37,20 @@ const products = [
     href: shopUrl,
   },
   {
-    title: 'Color Palette',
-    eyebrow: 'Notion Tools',
+    title: 'Themes / Goal Management',
+    eyebrow: '目標管理',
     description:
-      'Notionページづくりの色選びを助けるパレット。整える時間そのものが少し楽しくなる道具です。',
-    image: '/page/palette.png',
-    href: 'https://suzuri.jp/crossn/digital_products/7685',
+      'やりたいことを、日々の行動へほどいていくNotionテンプレート。迷子になりがちな目標を、見返せる形に整えます。',
+    image: '/page/tmg-fb.png',
+    href: 'https://suzuri.jp/crossn/digital_products/4871',
+  },
+  {
+    title: 'Themes / Goal Management Lite',
+    eyebrow: '目標管理 Lite',
+    description:
+      'Goal Managementの考え方を、より軽く始められる形にしたLite版。まず小さく整えたい人向けです。',
+    image: '/templates/themes-goal-management-lite.png',
+    href: shopUrl,
   },
 ]
 ---
@@ -102,8 +102,8 @@ const products = [
         <p class="sectionLabel">Templates</p>
         <h2 id="templates-title">いま公開しているテンプレート。</h2>
         <p>
-          目標管理、思考整理、ページづくりの見た目を整えるためのNotionテンプレートと小さなツールです。
-          詳細や購入はSUZURIの販売ページで確認できます。
+          思考を集める、ページの雰囲気を整える、目標を見返せる形にする。
+          その時々のつくりたい形に合わせて選べるNotionテンプレートと小さなツールです。
         </p>
       </div>
 

--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -1,13 +1,23 @@
 .container {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(220px, 300px);
-  gap: clamp(2rem, 5vw, 4rem);
-  max-width: 1120px;
+  grid-template-areas: 'sidebar article toc';
+  grid-template-columns: minmax(210px, 260px) minmax(0, 920px) minmax(52px, 240px);
+  gap: clamp(1.5rem, 3vw, 3rem);
+  align-items: start;
+  max-width: 1500px;
   margin: 0 auto;
-  padding: clamp(2.5rem, 7vw, 5.5rem) 0 clamp(4rem, 8vw, 6rem);
+  padding: clamp(2.5rem, 7vw, 5.5rem) clamp(0.8rem, 2.5vw, 2rem)
+    clamp(4rem, 8vw, 6rem);
 }
 
-.container main {
+.withoutToc {
+  grid-template-areas: 'sidebar article';
+  grid-template-columns: minmax(210px, 270px) minmax(0, 980px);
+  max-width: 1320px;
+}
+
+.article {
+  grid-area: article;
   min-width: 0;
 }
 
@@ -28,7 +38,8 @@
   border-top: 1px solid rgba(80, 70, 110, 0.12);
 }
 
-.container aside {
+.sidebar {
+  grid-area: sidebar;
   position: sticky;
   top: 1.5rem;
   align-self: start;
@@ -38,6 +49,15 @@
   border-radius: 18px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(250, 247, 255, 0.72));
   box-shadow: 0 18px 44px rgba(76, 60, 120, 0.08);
+}
+
+.tocSidebar {
+  grid-area: toc;
+  position: sticky;
+  top: 1.5rem;
+  align-self: start;
+  min-width: 0;
+  padding: 1.1rem 0.2rem;
 }
 
 .post {
@@ -152,13 +172,41 @@
   border: 0;
 }
 
-@media (max-width: 880px) {
+@media (max-width: 1180px) {
   .container {
+    grid-template-columns: minmax(190px, 240px) minmax(0, 900px) 3rem;
+    gap: clamp(1rem, 2.2vw, 2rem);
+  }
+
+  .tocSidebar {
+    padding: 0;
+  }
+}
+
+@media (max-width: 980px) {
+  .container,
+  .withoutToc {
+    grid-template-areas: 'sidebar article';
+    grid-template-columns: minmax(190px, 240px) minmax(0, 1fr);
+    max-width: 1180px;
+  }
+
+  .tocSidebar {
+    display: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .container,
+  .withoutToc {
+    grid-template-areas:
+      'article'
+      'sidebar';
     grid-template-columns: 1fr;
     padding-top: 2rem;
   }
 
-  .container aside {
+  .sidebar {
     position: static;
   }
 }

--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -1,12 +1,35 @@
 .container {
   display: grid;
-  grid-template-areas: 'sidebar article toc';
-  grid-template-columns: minmax(210px, 260px) minmax(0, 920px) minmax(52px, 240px);
-  gap: clamp(1.5rem, 3vw, 3rem);
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 300px);
+  gap: clamp(2rem, 5vw, 4rem);
   align-items: start;
-  max-width: 1500px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: clamp(2.5rem, 7vw, 5.5rem) clamp(0.8rem, 2.5vw, 2rem)
+  padding: clamp(2.5rem, 7vw, 5.5rem) 0 clamp(4rem, 8vw, 6rem);
+}
+
+.container > main {
+  min-width: 0;
+}
+
+.container > aside {
+  position: sticky;
+  top: 1.5rem;
+  align-self: start;
+  min-width: 0;
+  padding: 1.1rem;
+  border: 1px solid rgba(124, 108, 242, 0.14);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(250, 247, 255, 0.72));
+  box-shadow: 0 18px 44px rgba(76, 60, 120, 0.08);
+}
+
+.withToc {
+  grid-template-areas: 'sidebar article toc';
+  grid-template-columns: minmax(230px, 300px) minmax(0, 1040px) minmax(180px, 240px);
+  gap: clamp(0.75rem, 1.2vw, 1.25rem);
+  max-width: 1640px;
+  padding: clamp(2.5rem, 7vw, 5.5rem) clamp(0.4rem, 1vw, 1rem)
     clamp(4rem, 8vw, 6rem);
 }
 
@@ -14,6 +37,8 @@
   grid-template-areas: 'sidebar article';
   grid-template-columns: minmax(210px, 270px) minmax(0, 980px);
   max-width: 1320px;
+  padding: clamp(2.5rem, 7vw, 5.5rem) clamp(0.8rem, 2.5vw, 2rem)
+    clamp(4rem, 8vw, 6rem);
 }
 
 .article {
@@ -40,24 +65,19 @@
 
 .sidebar {
   grid-area: sidebar;
-  position: sticky;
-  top: 1.5rem;
-  align-self: start;
-  min-width: 0;
-  padding: 1.1rem;
-  border: 1px solid rgba(124, 108, 242, 0.14);
-  border-radius: 18px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(250, 247, 255, 0.72));
-  box-shadow: 0 18px 44px rgba(76, 60, 120, 0.08);
 }
 
-.tocSidebar {
+.container > .tocSidebar {
   grid-area: toc;
   position: sticky;
   top: 1.5rem;
   align-self: start;
+  justify-self: stretch;
   min-width: 0;
-  padding: 1.1rem 0.2rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .post {
@@ -172,32 +192,67 @@
   border: 0;
 }
 
-@media (max-width: 1180px) {
-  .container {
-    grid-template-columns: minmax(190px, 240px) minmax(0, 900px) 3rem;
+@media (max-width: 1320px) {
+  .withToc {
+    grid-template-columns: minmax(180px, 220px) minmax(0, 1040px) 3rem;
     gap: clamp(1rem, 2.2vw, 2rem);
   }
 
-  .tocSidebar {
+  .container > .tocSidebar {
+    display: flex;
+    justify-content: flex-end;
+    width: 3rem;
+    max-width: 3rem;
+    justify-self: end;
+    overflow: visible;
     padding: 0;
   }
 }
 
 @media (max-width: 980px) {
-  .container,
-  .withoutToc {
-    grid-template-areas: 'sidebar article';
-    grid-template-columns: minmax(190px, 240px) minmax(0, 1fr);
-    max-width: 1180px;
+  .withToc {
+    grid-template-areas:
+      'article toc'
+      'sidebar sidebar';
+    grid-template-columns: minmax(0, 1fr) 3rem;
+    max-width: 1120px;
   }
 
-  .tocSidebar {
-    display: none;
+  .container > .tocSidebar {
+    display: flex;
+    justify-content: flex-end;
+    width: 3rem;
+    max-width: 3rem;
+    justify-self: end;
+    overflow: visible;
+  }
+
+  .withoutToc {
+    grid-template-areas:
+      'article'
+      'sidebar';
+    grid-template-columns: 1fr;
+    max-width: 920px;
+  }
+
+  .sidebar {
+    position: static;
   }
 }
 
-@media (max-width: 760px) {
-  .container,
+@media (max-width: 880px) {
+  .container:not(.withToc):not(.withoutToc) {
+    grid-template-columns: 1fr;
+    padding-top: 2rem;
+  }
+
+  .container:not(.withToc):not(.withoutToc) > aside {
+    position: static;
+  }
+}
+
+@media (max-width: 700px) {
+  .withToc,
   .withoutToc {
     grid-template-areas:
       'article'
@@ -206,8 +261,8 @@
     padding-top: 2rem;
   }
 
-  .sidebar {
-    position: static;
+  .container > .tocSidebar {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## 変更内容

- Blog詳細ページに右側追従目次を追加
- 目次の現在位置判定とレスポンシブ表示を調整
- Blog一覧ページと詳細ページのレイアウトを整理
- H4 / H4 Toggle に対応
- PDF / Tab / unsupported ブロックに対応
- Link to page を page mention として表示できるように修正
- シンプルテーブルのセル結合推測と列幅を改善
- Homeのテンプレート表示順と説明文を調整

## 確認

- `npm run lint`
- `npm run build`

## メモ

Notion APIからシンプルテーブルの結合情報が明示的に取得できないケースがあったため、空白セルの並びから `rowspan` / `colspan` を推測する形にしています。

結合させたくないセルは、空白ではなく `-` など任意の値を入れる運用を想定しています。